### PR TITLE
Fix for https://github.com/himdel/lint-po/issues/1

### DIFF
--- a/lint_po/main.py
+++ b/lint_po/main.py
@@ -6,7 +6,7 @@ from sys import stderr
 import warnings
 
 # find any {num} {str} <num> </num> <num/> %(str)s
-REGEX = r'(\{(\w+|\d+)\})|(<\/?\d+\/?>)|(%(\(\w+\))?.)'
+REGEX = r'(\{(\w+|\d+)\})|(<\/?\d+\/?>)|(%(\(\w+\))?\w)'
 
 PLURAL_REGEX = r'^{(\w+), plural, .*}$'
 


### PR DESCRIPTION
Regex now a bit stronger as placeholder actually expected to be one of:
"%(var_name)s"
"%(var_name)d"
etc