### PR TITLE
Allow missing placeholders in singular plural forms

### DIFF
--- a/lint_po/main.py
+++ b/lint_po/main.py
@@ -79,7 +79,9 @@ def process_plural(msgid, msgid_plural, msgstrs, file, line):
       continue
 
     actual = set(extract(msgstr))
-    missing = expected - actual
+    # allow missing placeholders in singular forms (n=0, n=1) since
+    # translators often omit e.g. {count} ("No items", "One item")
+    missing = expected - actual if idx >= 2 else set()
     extra = actual - expected
 
     if len(missing) or len(extra):


### PR DESCRIPTION
Allow omitting placeholders like {count} in msgstr[0] and msgstr[1] (n=0 and n=1 plural forms), since translators often use fixed text there (e.g. "No items", "One item").

Extra/unexpected placeholders are still flagged in all forms.